### PR TITLE
Provide better subplots completions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       run: uv run ruff check src/eriplots
 
     - name: Run pytest with coverage
-      run: uv run pytest
+      run: uv run pytest --cov=src/eriplots --cov-branch --cov-report=term-missing --cov-report=html --cov-report=json
 
     - name: Run mypy
       run: uv run mypy src/eriplots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.2] – 2025-04-10
+
+### Added
+
+- `AxesArray`, `AxesArray1D`, and `AxesArray2D`: thin wrappers
+  around NumPy arrays of `Axes` to support type hinting and
+  autocompletion for users following usual patterns.
+
+### Changed
+
+- `subplots()` now returns one of the `AxesArray` subclasses (or
+  just `Axes`) depending on the requested rows and columns. These
+  arrays support autocompletion much better than the usual NumPy
+  ones but should perform just the same.
 
 ## [0.1.1] – 2025-04-09
 
@@ -30,3 +43,4 @@ First *eriplots* release!
 [Unreleased]: https://github.com/ElderResearch/eriplots-python/compare/0.1.0...develop
 [0.1.0]: https://github.com/ElderResearch/eriplots-python/releases/tag/0.1.0
 [0.1.1]: https://github.com/ElderResearch/eriplots-python/releases/tag/0.1.1
+[0.1.2]: https://github.com/ElderResearch/eriplots-python/releases/tag/0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.1.1] – 2025-04-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,3 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pytest.ini_options]
-addopts = "--cov=src/eriplots --cov-branch --cov-report=term-missing --cov-report=html --cov-report=json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eriplots"
-version = "0.1.1"
+version = "0.1.2"
 description = """
     A collection of tools for creating clean and consistent plots
     using matplotlib. Provides standardized themes and tools for

--- a/src/eriplots/mpl.py
+++ b/src/eriplots/mpl.py
@@ -2,22 +2,123 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Literal, Optional, Union, overload
 
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+from numpy import flatiter
 from numpy.typing import NDArray
 
 __all__ = ["subplots"]
+
+
+# AxesArray objects to better hint subplots outputs ------------------
+
+KeyLike1D = Union[int, slice, tuple[int], tuple[slice]]
+
+
+class AxesArray:
+    def __init__(self, array: NDArray):
+        self.np = array
+
+    # Operate with numpy
+    def __array__(self) -> NDArray:
+        return self.np
+
+    # Automatically dispatch to numpy as a fallback
+    def __getattr__(self, name):
+        warnings.warn(f"Missing attribute '{name}' dispatching to NumPy")
+        return getattr(self.np, name)
+
+    # Basic numpy properties
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return self.np.shape
+
+    @property
+    def size(self) -> int:
+        return self.np.size
+
+    @property
+    def ndim(self) -> int:
+        return len(self.shape)
+
+    # Wrangling shapes
+    def flatten(self) -> AxesArray1D:
+        return AxesArray1D(self.np.flatten())
+
+    def ravel(self) -> AxesArray1D:
+        return AxesArray1D(self.np.ravel())
+
+    @property
+    def flat(self) -> flatiter[NDArray]:
+        return self.np.flat
+
+
+class AxesArray1D(AxesArray):
+    @overload
+    def __getitem__(self, key: Union[int, tuple[int]]) -> Axes: ...
+
+    @overload
+    def __getitem__(self, key: Union[slice, tuple[slice]]) -> AxesArray1D: ...
+
+    def __getitem__(
+        self, key: Union[int, slice, tuple[int], tuple[slice]]
+    ) -> Union[Axes, AxesArray1D]:
+        selection = self.np[key]
+        if isinstance(selection, Axes):
+            return selection
+        if isinstance(selection, np.ndarray) and selection.ndim == 1:
+            return AxesArray1D(selection.view())
+        raise ValueError(f"Invalid selection type or dimensionality: {type(selection)}")
+
+
+class AxesArray2D(AxesArray):
+    @overload
+    def __getitem__(self, key: tuple[int, int]) -> Axes: ...
+
+    @overload
+    def __getitem__(
+        self, key: Union[int, tuple[int], tuple[int, slice], tuple[slice, int]]
+    ) -> AxesArray1D: ...
+
+    @overload
+    def __getitem__(
+        self, key: Union[slice, tuple[slice], tuple[slice, slice]]
+    ) -> AxesArray2D: ...
+
+    def __getitem__(
+        self,
+        key: Union[
+            int,
+            slice,
+            tuple[int],
+            tuple[slice],
+            tuple[int, int],
+            tuple[slice, slice],
+            tuple[int, slice],
+            tuple[slice, int],
+        ],
+    ) -> Union[Axes, AxesArray1D, AxesArray2D]:
+        selection = self.np[key]
+        if isinstance(selection, Axes):
+            return selection
+        if isinstance(selection, np.ndarray):
+            if selection.ndim == 1:
+                return AxesArray1D(selection.view())
+            if selection.ndim == 2:
+                return AxesArray2D(selection.view())
+        raise ValueError(f"Invalid selection type or dimensionality: {type(selection)}")
 
 
 # Extended version of matplotlib.pyplot.subplots ---------------------
 
 
 @overload
-def subplots(
+def subplots(  # type: ignore  # This actually works
     nrows: Literal[1] = 1,
     ncols: Literal[1] = 1,
     figsize: Optional[tuple[float, float]] = None,
@@ -31,6 +132,32 @@ def subplots(
 
 @overload
 def subplots(
+    nrows: Literal[1] = 1,
+    ncols: int = ...,
+    figsize: Optional[tuple[float, float]] = None,
+    aspect: Optional[float] = None,
+    dpi: Optional[int] = None,
+    flatten: bool = False,
+    shift: Union[float, tuple[float, float], Literal[True]] = 0,
+    **kw,
+) -> tuple[Figure, AxesArray1D]: ...
+
+
+@overload
+def subplots(
+    nrows: int = ...,
+    ncols: Literal[1] = 1,
+    figsize: Optional[tuple[float, float]] = None,
+    aspect: Optional[float] = None,
+    dpi: Optional[int] = None,
+    flatten: bool = False,
+    shift: Union[float, tuple[float, float], Literal[True]] = 0,
+    **kw,
+) -> tuple[Figure, AxesArray1D]: ...
+
+
+@overload
+def subplots(
     nrows: int,
     ncols: int,
     figsize: Optional[tuple[float, float]] = None,
@@ -39,7 +166,7 @@ def subplots(
     flatten: bool = False,
     shift: Union[float, tuple[float, float], Literal[True]] = 0,
     **kw,
-) -> tuple[Figure, NDArray]: ...
+) -> tuple[Figure, AxesArray2D]: ...
 
 
 def subplots(
@@ -51,7 +178,7 @@ def subplots(
     flatten: bool = False,
     shift: Union[float, tuple[float, float], Literal[True]] = 0,
     **kw,
-) -> tuple[Figure, Union[Axes, NDArray]]:
+) -> tuple[Figure, Union[Axes, AxesArray1D, AxesArray2D]]:
     """Create a figure and one or more subplots.
 
     This extends matplotlib.pyplot.subplots().
@@ -110,8 +237,18 @@ def subplots(
     if flatten and not isinstance(axes, Axes) and axes.ndim > 1:
         axes = axes.flatten()
 
-    # Nonsense with mypy x matplotlib x numpy
-    return_axes: Union[Axes, NDArray]
-    return_axes = axes.item() if ncols == 1 and nrows == 1 else axes
+    # If only one figure, return Axes
+    if ncols == 1 and nrows == 1:
+        retax: Axes = axes.item()
+        return fig, retax
 
-    return fig, return_axes
+    # If a flat array, return AxesArray1D
+    elif axes.ndim == 1:
+        return fig, AxesArray1D(axes)
+
+    # Otherwise, return a 2D array
+    elif axes.ndim == 2:
+        return fig, AxesArray2D(axes)
+
+    else:
+        raise ValueError(f"Axes array has ndim = {axes.ndim}")

--- a/tests/test_mpl.py
+++ b/tests/test_mpl.py
@@ -1,10 +1,9 @@
 """Tests for matplotlib extensions."""
 
-import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
-from eriplots.mpl import subplots
+from eriplots.mpl import AxesArray1D, AxesArray2D, subplots
 
 
 def test_single_subplot():
@@ -18,14 +17,14 @@ def test_multiple_subplots():
     """Test that multiple subplots return a Figure and ndarray."""
     fig, axes = subplots(2, 2)
     assert isinstance(fig, Figure)
-    assert isinstance(axes, np.ndarray)
+    assert isinstance(axes, AxesArray2D)
     assert axes.shape == (2, 2)
 
 
 def test_flatten_subplots():
     """Test that flatten=True returns a 1D array for multi-subplots."""
     fig, axes = subplots(2, 3, flatten=True)
-    assert isinstance(axes, np.ndarray)
+    assert isinstance(axes, AxesArray1D)
     assert axes.ndim == 1
     assert axes.size == 6
 
@@ -83,7 +82,7 @@ def test_row_subplots():
     """Test for row of subplots (single row, multiple columns)."""
     fig, axes = subplots(1, 3)
     assert isinstance(fig, Figure)
-    assert isinstance(axes, np.ndarray)
+    assert isinstance(axes, AxesArray1D)
     assert axes.shape == (3,)
 
 
@@ -91,5 +90,56 @@ def test_column_subplots():
     """Test for column of subplots (multiple rows, single column)."""
     fig, axes = subplots(3, 1)
     assert isinstance(fig, Figure)
-    assert isinstance(axes, np.ndarray)
+    assert isinstance(axes, AxesArray1D)
     assert axes.shape == (3,)
+
+
+def test_2d_subplots():
+    """Test a 2D plot layout."""
+    fig, axes = subplots(2, 2)
+    assert isinstance(fig, Figure)
+    assert isinstance(axes, AxesArray2D)
+    assert axes.shape == (2, 2)
+
+
+def test_axes_array_1d_indexing():
+    """Test indexing behavior of AxesArray1D."""
+    fig, axes = subplots(1, 3)
+    assert isinstance(axes, AxesArray1D)
+
+    # Test single index returns Axes
+    assert isinstance(axes[0], Axes)
+    assert isinstance(axes[-1], Axes)
+
+    # Test slice returns AxesArray1D
+    sliced = axes[:1]
+    assert isinstance(sliced, AxesArray1D)
+    assert sliced.np.shape == (1,)
+
+    # Test tuple indexing returns Axes
+    assert isinstance(axes[(0,)], Axes)
+    assert isinstance(axes[(-1,)], Axes)
+
+
+def test_axes_array_2d_indexing():
+    """Test indexing behavior of AxesArray2D."""
+    fig, axes = subplots(2, 2)
+    assert isinstance(axes, AxesArray2D)
+
+    # Test double integer returns Axes
+    assert isinstance(axes[0, 0], Axes)
+    assert isinstance(axes[0, -1], Axes)
+    assert isinstance(axes[-1, 0], Axes)
+    assert isinstance(axes[-1, -1], Axes)
+
+    # Single integer returns 1D array
+    assert isinstance(axes[0], AxesArray1D)
+    assert isinstance(axes[-1], AxesArray1D)
+    assert isinstance(axes[0, :], AxesArray1D)
+    assert isinstance(axes[:, 0], AxesArray1D)
+    assert isinstance(axes[(0,)], AxesArray1D)
+
+    # But these should be 2D arrays
+    assert isinstance(axes[:, :], AxesArray2D)
+    assert isinstance(axes[:, :1], AxesArray2D)
+    assert isinstance(axes[:1, :1], AxesArray2D)

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "eriplots"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "cycler" },


### PR DESCRIPTION
### Added

- `AxesArray`, `AxesArray1D`, and `AxesArray2D`: thin wrappers
  around NumPy arrays of `Axes` to support type hinting and
  autocompletion for users following usual patterns.

### Changed

- `subplots()` now returns one of the `AxesArray` subclasses (or
  just `Axes`) depending on the requested rows and columns. These
  arrays support autocompletion much better than the usual NumPy
  ones but should perform just the same.