### PR TITLE
Version 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `alpha(n, max_opacity=0.85)` computes layer opacities such that
   n layers stack with a cumulative `max_opacity`.
 
+### Changed
+
+- (DEV) Added isort rules to Ruff
+
 ## [0.1.2] – 2025-04-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.1.2] – 2025-04-10
 
 ### Added
@@ -40,7 +42,7 @@ First *eriplots* release!
 - Save figures in multiple formats
 - Color palettes and colormaps
 
-[Unreleased]: https://github.com/ElderResearch/eriplots-python/compare/0.1.0...develop
+[Unreleased]: https://github.com/ElderResearch/eriplots-python/compare/0.1.2...develop
 [0.1.0]: https://github.com/ElderResearch/eriplots-python/releases/tag/0.1.0
 [0.1.1]: https://github.com/ElderResearch/eriplots-python/releases/tag/0.1.1
 [0.1.2]: https://github.com/ElderResearch/eriplots-python/releases/tag/0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `alpha(n, max_opacity=0.85)` computes layer opacities such that
+  n layers stack with a cumulative `max_opacity`.
+
 ## [0.1.2] – 2025-04-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.3] – 2025-04-25
 
 ### Changed
 
@@ -59,7 +59,7 @@ First *eriplots* release!
 - Save figures in multiple formats
 - Color palettes and colormaps
 
-[Unreleased]: https://github.com/ElderResearch/eriplots-python/compare/0.1.2...develop
 [0.1.0]: https://github.com/ElderResearch/eriplots-python/releases/tag/0.1.0
 [0.1.1]: https://github.com/ElderResearch/eriplots-python/releases/tag/0.1.1
 [0.1.2]: https://github.com/ElderResearch/eriplots-python/releases/tag/0.1.2
+[0.1.3]: https://github.com/ElderResearch/eriplots-python/releases/tag/0.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added `__iter()__` methods to `AxesArray1D` and `AxesArray2D` to
+  support type hinting with `zip()`.
+- `AxesArray.__getattr__()` no longer warns when private properties
+  are passed on to its underlying NumPy object. Examining an
+  `AxesArray1D` in Jupyter led to a casacade of warnings.
+
 ### Added
 
 - `alpha(n, max_opacity=0.85)` computes layer opacities such that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eriplots"
-version = "0.1.3.dev0"
+version = "0.1.3"
 description = """
     A collection of tools for creating clean and consistent plots
     using matplotlib. Provides standardized themes and tools for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,13 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.ruff]
+target-version = "py39"
+
+[tool.ruff.lint]
+extend-select = ["I"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["eriplots"]
+known-third-party = ["matplotlib", "numpy", "pytest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eriplots"
-version = "0.1.2"
+version = "0.1.3.dev0"
 description = """
     A collection of tools for creating clean and consistent plots
     using matplotlib. Provides standardized themes and tools for

--- a/src/eriplots/__init__.py
+++ b/src/eriplots/__init__.py
@@ -10,7 +10,7 @@
 from importlib import metadata as _metadata
 
 from eriplots import colormaps, styles
-from eriplots.mpl import subplots
+from eriplots.mpl import alpha, subplots
 from eriplots.palettes import colors
 from eriplots.savefig import save_figures
 from eriplots.styles import eri_style
@@ -22,6 +22,7 @@ __all__ = [
     "save_figures",
     "colormaps",
     "styles",
+    "alpha",
 ]
 
 # https://packaging.python.org/en/latest/guides/single-sourcing-package-version/

--- a/src/eriplots/mpl.py
+++ b/src/eriplots/mpl.py
@@ -12,8 +12,7 @@ from matplotlib.figure import Figure
 from numpy import flatiter
 from numpy.typing import NDArray
 
-__all__ = ["subplots"]
-
+__all__ = ["subplots", "alpha"]
 
 # AxesArray objects to better hint subplots outputs ------------------
 
@@ -339,3 +338,40 @@ def subplots(
 
     else:
         raise ValueError(f"Axes array has ndim = {axes.ndim}")
+
+
+# Layer alpha values -------------------------------------------------
+
+
+def alpha(n: int, max_opacity: float = 0.85) -> float:
+    """Calculate alpha levels for stacked plot components.
+
+    This function calculates alpha (opacity) values for plot components
+    so that when n layers are stacked they have overall alpha =
+    max_opacity.
+
+    Args:
+        n: Target number of stacked layers.
+        max_opacity: The maximum opacity value at n (default: 0.85).
+
+    Returns:
+        A float between 0 and max_opacity.
+
+    Examples:
+        >>> alpha(1)  # Single component
+        0.85
+        >>> alpha(2)  # Two components, each with alpha ~ 0.613
+        0.6127016653792583
+        >>> alpha(3)  # Three components, each with alpha ~ 0.469
+        0.4686707154086944
+        >>> alpha(2, max_opacity=0.8)  # Custom max opacity
+        0.5527864045000421
+
+    """
+    if n <= 0:
+        raise ValueError("n must be positive")
+
+    if max_opacity <= 0 or max_opacity > 1:
+        raise ValueError("max_opacity must be between 0 and 1")
+
+    return 1 - (1 - max_opacity) ** (1 / n)

--- a/src/eriplots/mpl.py
+++ b/src/eriplots/mpl.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Literal, Optional, Union, overload
+from typing import Iterator, Literal, Optional, Union, overload
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -42,9 +42,10 @@ class AxesArray:
         """Mark this class as available for use with NumPy."""
         return self.np
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str):
         """Automatically dispatch to NumPy as a fallback."""
-        warnings.warn(f"Missing attribute '{name}' dispatching to NumPy")
+        if not name.startswith("_"):
+            warnings.warn(f"Missing attribute '{name}' dispatching to NumPy")
         return getattr(self.np, name)
 
     # Basic numpy properties
@@ -88,6 +89,10 @@ class AxesArray1D(AxesArray):
         >>> isinstance(axes[1:], AxesArray1D)  # Slice returns AxesArray1D
         True
     """
+
+    def __iter__(self) -> Iterator[Axes]:
+        for ax in self.np:
+            yield ax
 
     @overload
     def __getitem__(self, key: Union[int, tuple[int]]) -> Axes: ...
@@ -141,6 +146,10 @@ class AxesArray2D(AxesArray):
         >>> isinstance(axes[:, :1], AxesArray2D)  # Slice returns AxesArray2D
         True
     """
+
+    def __iter__(self) -> Iterator[AxesArray1D]:
+        for arr in self.np:
+            yield AxesArray1D(arr.view())
 
     @overload
     def __getitem__(self, key: tuple[int, int]) -> Axes: ...

--- a/src/eriplots/savefig.py
+++ b/src/eriplots/savefig.py
@@ -1,10 +1,10 @@
 """Save raster and vector figures together."""
 
-from typing import Literal, Optional, Union
-from matplotlib.figure import Figure
 from pathlib import Path
-from subprocess import check_call, CalledProcessError, PIPE, DEVNULL
+from subprocess import DEVNULL, PIPE, CalledProcessError, check_call
+from typing import Literal, Optional, Union
 
+from matplotlib.figure import Figure
 
 _SaveTypes = Literal["pdf", "svg", "eps", "png", "tiff", "webp"]
 _optipng: Optional[bool] = None

--- a/src/eriplots/styles.py
+++ b/src/eriplots/styles.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from typing import Any, Final, Literal, Optional
+
 from cycler import cycler
-from eriplots.palettes import colors
 from matplotlib.pyplot import rcParams
+
+from eriplots.palettes import colors
 
 __all__ = ["eri_style", "font_rel", "font_abs"]
 

--- a/tests/test_mpl.py
+++ b/tests/test_mpl.py
@@ -2,8 +2,9 @@
 
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+import pytest
 
-from eriplots.mpl import AxesArray1D, AxesArray2D, subplots
+from eriplots.mpl import AxesArray1D, AxesArray2D, subplots, alpha
 
 
 def test_single_subplot():
@@ -143,3 +144,48 @@ def test_axes_array_2d_indexing():
     assert isinstance(axes[:, :], AxesArray2D)
     assert isinstance(axes[:, :1], AxesArray2D)
     assert isinstance(axes[:1, :1], AxesArray2D)
+
+
+def test_alpha_basic():
+    """Test basic alpha calculations."""
+    # Single component should have full opacity
+    assert alpha(1) == 0.85
+
+    # Two components should have alpha that when stacked reaches 1.0
+    a2 = alpha(2)
+    assert 1 - (1 - a2) ** 2 == 0.85
+
+    # Three components should have alpha that when stacked reaches 1.0
+    a3 = alpha(3)
+    assert 1 - (1 - a3) ** 3 == 0.85
+
+
+def test_alpha_max_opacity():
+    """Test alpha calculations with custom max_opacity."""
+    max_opacity = 0.8
+
+    # Single component should have specified max_opacity
+    assert alpha(1, max_opacity) == max_opacity
+
+    # Two components should have alpha that when stacked reaches max_opacity
+    a2 = alpha(2, max_opacity)
+    assert 1 - (1 - a2) ** 2 == max_opacity
+
+    # Three components should have alpha that when stacked reaches max_opacity
+    a3 = alpha(3, max_opacity)
+    assert 1 - (1 - a3) ** 3 == max_opacity
+
+
+def test_alpha_invalid_inputs():
+    """Test that invalid inputs raise appropriate errors."""
+    # n must be positive
+    with pytest.raises(ValueError, match="n must be positive"):
+        alpha(0)
+    with pytest.raises(ValueError, match="n must be positive"):
+        alpha(-1)
+
+    # max_opacity must be between 0 and 1
+    with pytest.raises(ValueError, match="max_opacity must be between 0 and 1"):
+        alpha(1, -0.1)
+    with pytest.raises(ValueError, match="max_opacity must be between 0 and 1"):
+        alpha(1, 1.1)

--- a/tests/test_mpl.py
+++ b/tests/test_mpl.py
@@ -1,10 +1,10 @@
 """Tests for matplotlib extensions."""
 
+import pytest
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
-import pytest
 
-from eriplots.mpl import AxesArray1D, AxesArray2D, subplots, alpha
+from eriplots.mpl import AxesArray1D, AxesArray2D, alpha, subplots
 
 
 def test_single_subplot():

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ wheels = [
 
 [[package]]
 name = "eriplots"
-version = "0.1.1"
+version = "0.1.3.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "cycler" },


### PR DESCRIPTION
### Changed

- Added `__iter()__` methods to `AxesArray1D` and `AxesArray2D` to
  support type hinting with `zip()`.
- `AxesArray.__getattr__()` no longer warns when private properties
  are passed on to its underlying NumPy object. Examining an
  `AxesArray1D` in Jupyter led to a casacade of warnings.

### Added

- `alpha(n, max_opacity=0.85)` computes layer opacities such that
  n layers stack with a cumulative `max_opacity`.

### Changed

- (DEV) Added isort rules to Ruff